### PR TITLE
Use search key to open facebook search

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -59,4 +59,17 @@
 \nThis app is for those users that require a Tinfoil Hat when logging in to Facebook. It creates a sandbox for facebook\'s mobile site to avoid them tracking your browsing history. Requires INTERNET permissions, and if you are skeptic about it, feel free to check the source code listed above. Coarse location permissions are required but location is not used unless you turn \"Allow Check-ins\" in the preferences.\n
 \n
 	</string>
+	
+<!-- Formatted javascript to open search box
+		var SPACING=250; (function() {
+		    document.querySelector("td.left > a.pageHeaderChromelessButton").click(); 
+		    setTimeout(function() {
+		        document.querySelector("div.mSideSearch").click();
+		        setTimeout(function() {
+		            document.querySelector("input.input.mSearchInput").focus();
+		        }, SPACING);
+		    }, SPACING);
+		})();
+-->
+    <string name="search_js">javascript: var SPACING=250; (function() { document.querySelector(\"td.left > a.pageHeaderChromelessButton\").click(); setTimeout(function() { document.querySelector(\"div.mSideSearch\").click(); setTimeout(function() { document.querySelector(\"input.input.mSearchInput\").focus(); }, SPACING); }, SPACING); })();</string>
 </resources>

--- a/src/com/danvelazco/fbwrapper/FbWrapper.java
+++ b/src/com/danvelazco/fbwrapper/FbWrapper.java
@@ -409,9 +409,19 @@ public class FbWrapper extends Activity {
         if ((keyCode == KeyEvent.KEYCODE_BACK) && mFBWrapper.canGoBack()) {
         	mFBWrapper.goBack();
             return true;
+        } else if (keyCode == KeyEvent.KEYCODE_SEARCH)
+        {
+        	openSearchBox();
         }
         
         return super.onKeyDown(keyCode, event);
+    }
+    
+    /*
+     * Use some hacky js to open the search box in the webview
+     */
+    private void openSearchBox() {
+    	mFBWrapper.loadUrl(getResources().getString(R.string.search_js));
     }
     
     @Override


### PR DESCRIPTION
This isn't a pull request in the traditional sense: this commit doesn't work so you shouldn't merge it. Just wanted to bring your attention to the idea.

Basically, when you press the hard search button, the Facebook search would open via javascript calls to the `WebView`..

The code I've added _should_ work with some minor tweaks. For some reason the javascript isn't executing as it should on the device (runs fine in modern browsers on the desktop).

Let me know what you think.
