### PR TITLE
friend tagging feature

### DIFF
--- a/Tinfoil-for-Facebook/src/main/java/com/danvelazco/fbwrapper/AccessTokenDialogFragment.java
+++ b/Tinfoil-for-Facebook/src/main/java/com/danvelazco/fbwrapper/AccessTokenDialogFragment.java
@@ -1,0 +1,93 @@
+package com.danvelazco.fbwrapper;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import com.danvelazco.fbwrapper.activity.BaseFacebookWebViewActivity;
+import com.danvelazco.fbwrapper.preferences.FacebookPreferences;
+
+import android.app.DialogFragment;
+import android.os.AsyncTask;
+import android.os.Bundle;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.View.OnClickListener;
+import android.view.ViewGroup.LayoutParams;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.webkit.WebChromeClient;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
+import android.widget.AdapterView;
+import android.widget.AdapterView.OnItemClickListener;
+import android.widget.ArrayAdapter;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.FrameLayout;
+import android.widget.LinearLayout;
+import android.widget.ListView;
+import android.widget.Toast;
+
+public class AccessTokenDialogFragment extends DialogFragment {
+	
+	private WebView mWebView;
+	
+	public static AccessTokenDialogFragment newInstance() {
+		AccessTokenDialogFragment f = new AccessTokenDialogFragment();
+        f.setArguments(new Bundle());
+        return f;
+	}
+	
+	@Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+	}
+	
+	@Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        final View v = inflater.inflate(R.layout.access_token_fragment_dialog, container, false);
+        
+        int width = getResources().getDisplayMetrics().widthPixels;
+        int height = getResources().getDisplayMetrics().heightPixels;
+        v.findViewById(R.id.access_layout).setMinimumHeight((int) (height*0.7));
+        v.findViewById(R.id.access_layout).setMinimumWidth((int) (width*0.9));
+        getDialog().requestWindowFeature(Window.FEATURE_NO_TITLE);
+        
+        mWebView = (WebView)v.findViewById(R.id.access_webview);
+        mWebView.setWebViewClient(new WebViewClient() {
+        	
+        	@Override
+        	public boolean shouldOverrideUrlLoading(WebView view, String url) {
+        		if (url.startsWith("https://alexburka.com/tinfoil")) {
+        			((FacebookPreferences)getActivity()).received_access_token(url.split("=")[1].split("&")[0]);
+        			dismiss();
+        			return true;
+        		}
+        		return false;
+        	}
+        	
+        	@Override
+        	public void onReceivedError(WebView view, int errorCode, String description, String failingUrl) {
+        		Toast.makeText(getActivity(), "Internet error: " + description, Toast.LENGTH_SHORT).show();
+        		dismiss();
+        	}
+        });
+        mWebView.loadUrl("https://graph.facebook.com/oauth/authorize?type=user_agent&client_id=266257470187937&redirect_uri=https%3A%2F%2Falexburka.com%2Ftinfoil&scope=user_friends&offline_access=true");
+
+        return v;
+    }
+
+}

--- a/Tinfoil-for-Facebook/src/main/java/com/danvelazco/fbwrapper/FbWrapper.java
+++ b/Tinfoil-for-Facebook/src/main/java/com/danvelazco/fbwrapper/FbWrapper.java
@@ -1,6 +1,9 @@
 package com.danvelazco.fbwrapper;
 
 import android.app.AlertDialog;
+import android.app.DialogFragment;
+import android.app.Fragment;
+import android.app.FragmentTransaction;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -8,6 +11,7 @@ import android.content.res.Configuration;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.SystemClock;
 import android.preference.PreferenceManager;
 import android.support.v4.view.GravityCompat;
 import android.support.v4.widget.DrawerLayout;
@@ -136,6 +140,7 @@ public class FbWrapper extends BaseFacebookWebViewActivity {
         findViewById(R.id.menu_item_newsfeed).setOnClickListener(buttonsListener);
         findViewById(R.id.menu_items_notifications).setOnClickListener(buttonsListener);
         findViewById(R.id.menu_item_messages).setOnClickListener(buttonsListener);
+        findViewById(R.id.menu_item_tag).setOnClickListener(buttonsListener);
         findViewById(R.id.menu_share_this).setOnClickListener(buttonsListener);
         findViewById(R.id.menu_preferences).setOnClickListener(buttonsListener);
         findViewById(R.id.menu_about).setOnClickListener(buttonsListener);
@@ -327,6 +332,9 @@ public class FbWrapper extends BaseFacebookWebViewActivity {
                 case R.id.menu_item_messages:
                 	loadNewPage(mDomainToUse + URL_PAGE_MESSAGES);
                 	break;
+                case R.id.menu_item_tag:
+                	tagFriend();
+                	break;
                 case R.id.menu_share_this:
                     shareCurrentPage();
                     break;
@@ -362,6 +370,29 @@ public class FbWrapper extends BaseFacebookWebViewActivity {
                     }
                 });
         alertDialog.show();
+    }
+    
+    /**
+     * Search for a friend and insert tagging syntax.
+     */
+    private void tagFriend() {
+    	FragmentTransaction ft = getFragmentManager().beginTransaction();
+        Fragment prev = getFragmentManager().findFragmentByTag("tag_dialog");
+        if (prev != null) {
+            ft.remove(prev);
+        }
+        ft.addToBackStack(null);
+
+        // Create and show the dialog.
+        DialogFragment newFragment = TagFriendDialogFragment.newInstance();
+        newFragment.show(ft, "tag_dialog");
+    }
+    
+    public void friendTagged(String text) {    	
+    	// send text to WebView
+    	for (int i = 0; i < text.length(); ++i) {
+    		mWebView.dispatchKeyEvent(new KeyEvent(100, text.substring(i, i+1), 1, 0));
+    	}
     }
 
     /**

--- a/Tinfoil-for-Facebook/src/main/java/com/danvelazco/fbwrapper/TagFriendDialogFragment.java
+++ b/Tinfoil-for-Facebook/src/main/java/com/danvelazco/fbwrapper/TagFriendDialogFragment.java
@@ -1,0 +1,199 @@
+package com.danvelazco.fbwrapper;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import com.danvelazco.fbwrapper.activity.BaseFacebookWebViewActivity;
+
+import android.app.DialogFragment;
+import android.os.AsyncTask;
+import android.os.Bundle;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.View.OnClickListener;
+import android.view.ViewGroup;
+import android.view.WindowManager.LayoutParams;
+import android.widget.AdapterView;
+import android.widget.AdapterView.OnItemClickListener;
+import android.widget.ArrayAdapter;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.ListView;
+import android.widget.TextView;
+
+public class TagFriendDialogFragment extends DialogFragment {
+	
+	private class GraphSearchTask extends AsyncTask<String, Void, String> {
+
+		@Override
+		protected void onPreExecute() {
+			mID = ID_LOADING;
+			tag_list.setAdapter( new ArrayAdapter<String>(getActivity().getApplicationContext(), R.layout.simple_black_list_item, new String[]{"..."}));
+		}
+		
+		@Override
+		protected String doInBackground(String... names) {
+			String name = names[0];
+			
+			HttpClient client = new DefaultHttpClient();
+            String json = "";
+            try {
+                String line = "";
+                Log.d("TFD", BaseFacebookWebViewActivity.URL_GRAPH_SEARCH(getActivity(), name));
+                HttpGet request = new HttpGet(BaseFacebookWebViewActivity.URL_GRAPH_SEARCH(getActivity(), name));
+                HttpResponse response = client.execute(request);
+                BufferedReader rd = new BufferedReader(new InputStreamReader(response.getEntity().getContent()));
+                while ((line = rd.readLine()) != null) {
+                    json += line + System.getProperty("line.separator");
+                }
+            } catch (IllegalArgumentException e1) {
+                e1.printStackTrace();
+            } catch (IOException e2) {
+                e2.printStackTrace();
+            }
+            return json;
+		}
+		
+		@Override
+		protected void onPostExecute(String json) {
+			Log.d("TFD", json);
+			
+			mIDs.clear();
+			mFulls.clear();
+			mFirsts.clear();
+			mLasts.clear();
+			try {
+				JSONArray peeps = new JSONObject(json).getJSONArray("data");
+				for (int i = 0; i < peeps.length(); ++i) {
+					mIDs.add(peeps.getJSONObject(i).getString("uid"));
+					mFulls.add(peeps.getJSONObject(i).getString("name"));
+					mFirsts.add(peeps.getJSONObject(i).getString("first_name"));
+					mLasts.add(peeps.getJSONObject(i).getString("last_name"));
+				}
+				
+		        tag_list.setAdapter(new ArrayAdapter<String>(getActivity().getApplicationContext(), R.layout.simple_black_list_item, mFulls));
+		        mID = ID_CHOOSEFRIEND;
+			} catch (JSONException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+		}
+    	
+    }
+	
+	private View.OnClickListener mClickListener = null;
+    private TextWatcher mTextListener = null;
+    private GraphSearchTask mTask = null;
+    private static final int ID_LOADING = -1;
+    private static final int ID_CHOOSEFRIEND = -2;
+    private int mID = ID_LOADING;
+	private ArrayList<String> mIDs, mFulls, mFirsts, mLasts;
+	private EditText tag_in;
+	private ListView tag_list;
+	
+	static TagFriendDialogFragment newInstance() {
+		TagFriendDialogFragment f = new TagFriendDialogFragment();
+        f.setArguments(new Bundle());
+        return f;
+	}
+	
+	@Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+	}
+	
+	@Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        final View v = inflater.inflate(R.layout.tag_friend_fragment_dialog, container, false);
+        tag_in = (EditText)v.findViewById(R.id.tag_in);
+        tag_list = (ListView)v.findViewById(R.id.tag_list);
+        
+        getDialog().getWindow().setSoftInputMode(LayoutParams.SOFT_INPUT_STATE_VISIBLE);
+        
+        // List view adapter
+        ((ListView)v.findViewById(R.id.tag_list)).setAdapter( new ArrayAdapter<String>(getActivity().getApplicationContext(), R.layout.simple_black_list_item, new String[]{"enter name above"}));
+        
+        mIDs = new ArrayList<String>();
+        mFulls = new ArrayList<String>();
+        mFirsts = new ArrayList<String>();
+        mLasts = new ArrayList<String>();
+
+        // listeners
+        mTextListener = new TextWatcher() {
+
+    		@Override
+    		public void afterTextChanged(Editable s) {
+    			// don't care
+    			
+    		}
+
+    		@Override
+    		public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+    			// don't care
+    			
+    		}
+
+    		@Override
+    		public void onTextChanged(CharSequence s, int start, int before, int count) {   
+    			
+    			if (s.length() > 0) {
+    				if (mTask != null) mTask.cancel(true);
+    				mTask = new GraphSearchTask();
+    				mTask.execute(s.toString());
+    			}
+    		}
+        };
+
+        tag_in.addTextChangedListener(mTextListener);
+        tag_list.setOnItemClickListener(new OnItemClickListener() {
+
+			@Override
+			public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+				if (mID == ID_LOADING) {
+					return;
+				}
+				if (mID != ID_CHOOSEFRIEND) {
+					String name;
+					switch (position) {
+					case 0:
+						name = "0";
+						break;
+					case 1:
+						name = mFirsts.get(mID);
+						break;
+					case 2:
+						name = mLasts.get(mID);
+						break;
+					default:
+						return;
+					}
+					String str = "@[" + mIDs.get(mID) + ":" + name + "]";
+	            	
+	                ((FbWrapper)getActivity()).friendTagged(str);
+	                dismiss();
+				} else {
+					mID = position;
+				
+					tag_list.setAdapter( new ArrayAdapter<String>(getActivity().getApplicationContext(), R.layout.simple_black_list_item, new String[]{"tag as: " + mFulls.get(position), "tag as: " + mFirsts.get(position), "tag as: " + mLasts.get(position)}));
+				}
+			}
+        	
+        });
+
+        return v;
+    }
+
+}

--- a/Tinfoil-for-Facebook/src/main/java/com/danvelazco/fbwrapper/activity/BaseFacebookWebViewActivity.java
+++ b/Tinfoil-for-Facebook/src/main/java/com/danvelazco/fbwrapper/activity/BaseFacebookWebViewActivity.java
@@ -30,6 +30,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.text.TextUtils;
+import android.preference.PreferenceManager;
 import android.view.KeyEvent;
 import android.view.View;
 import android.webkit.CookieSyncManager;
@@ -47,6 +48,8 @@ import com.danvelazco.fbwrapper.webview.FacebookWebView;
 import com.danvelazco.fbwrapper.webview.FacebookWebViewClient;
 
 import java.io.File;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 
 /**
  * Base activity that uses a {@link FacebookWebView} to load the Facebook
@@ -68,7 +71,19 @@ public abstract class BaseFacebookWebViewActivity extends Activity implements
     protected final static String INIT_URL_DESKTOP = "https://www.facebook.com";
     protected final static String URL_PAGE_NOTIFICATIONS = "/notifications.php";
     protected final static String URL_PAGE_MESSAGES = "/messages";
-
+    
+    protected final static String DEBUG_ACCESS_TOKEN = "CAACEdEose0cBAMDYT6fmTjrpgUPRmvx6k30geaNCtWYyEOy9hFw1ma4jq6yHmiJ55ZCJsMhQOrlrGyAK1WNI0ggp11ZBig7UGNZCwd7wxYkZASyXL3xEZBVncwwlvqnxGHk5eeZCSHp86dlcwD1lS5wNO9b6Go2P4TlU337IexAq4opg1qZAItmUOTgBLDgJJwQuXICprEm9gZDZD";
+    public static String URL_GRAPH_SEARCH(Context ctx, String name) {
+    	try {
+    		String access_token = PreferenceManager.getDefaultSharedPreferences(ctx).getString("API_KEY", "");
+			return "https://graph.facebook.com/fql?access_token=" + access_token + "&q=" + URLEncoder.encode("select uid, name, first_name, last_name from user where uid in (SELECT uid2 FROM friend WHERE uid1 = me()) and strpos(lower(name), '" + name.toLowerCase() + "')>=0 limit 10", "UTF-8");
+		} catch (UnsupportedEncodingException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+			return "";
+		}
+    }
+    
     // URL for Sharing Links
     // u = url & t = title
     protected final static String URL_PAGE_SHARE_LINKS = "/sharer.php?u=%s&t=%s";

--- a/Tinfoil-for-Facebook/src/main/res/layout/access_token_fragment_dialog.xml
+++ b/Tinfoil-for-Facebook/src/main/res/layout/access_token_fragment_dialog.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/access_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" >
+
+    <com.danvelazco.fbwrapper.webview.FacebookWebView
+        android:id="@+id/access_webview"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+</FrameLayout>

--- a/Tinfoil-for-Facebook/src/main/res/layout/drawer_menu.xml
+++ b/Tinfoil-for-Facebook/src/main/res/layout/drawer_menu.xml
@@ -211,6 +211,37 @@
             android:text="@string/menu_messages"/>
 
     </RelativeLayout>
+    
+    <!-- Menu item: Tag friend -->
+    <RelativeLayout
+        android:id="@+id/menu_item_tag"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/navigation_drawer_items_height"
+        android:padding="@dimen/navigation_drawer_items_padding"
+        android:clickable="true"
+        android:focusable="true"
+        android:background="?android:selectableItemBackground">
+
+        <ImageView
+            android:id="@+id/iv_tag"
+            android:layout_width="@dimen/navigation_drawer_icon_size"
+            android:layout_height="@dimen/navigation_drawer_icon_size"
+            android:layout_centerVertical="true"
+            android:src="@android:drawable/ic_menu_search"
+            android:contentDescription="@string/menu_messages" />
+
+        <TextView
+            android:id="@+id/tv_tag"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerVertical="true"
+            android:layout_toRightOf="@+id/iv_tag"
+            android:layout_marginLeft="@dimen/navigation_drawer_items_icon_title_margin"
+            android:gravity="left"
+            style="@style/MenuDrawerTextStyle"
+            android:text="@string/menu_tag"/>
+
+    </RelativeLayout>
 
     <!-- Menu item: Share this page -->
     <RelativeLayout

--- a/Tinfoil-for-Facebook/src/main/res/layout/simple_black_list_item.xml
+++ b/Tinfoil-for-Facebook/src/main/res/layout/simple_black_list_item.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/tv"
+    android:textColor="@android:color/black"
+    android:padding="5sp"
+    android:layout_width="fill_parent"
+    android:singleLine="true"
+    android:gravity="center"
+    android:layout_height="fill_parent"/>

--- a/Tinfoil-for-Facebook/src/main/res/layout/tag_friend_fragment_dialog.xml
+++ b/Tinfoil-for-Facebook/src/main/res/layout/tag_friend_fragment_dialog.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical" >
+
+    <EditText
+        android:id="@+id/tag_in"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:ems="10"
+        android:inputType="text"
+        android:hint="@string/tag_in_hint" >
+
+        <requestFocus />
+    </EditText>
+
+    <ListView
+        android:id="@+id/tag_list"
+        android:layout_width="match_parent"
+        android:layout_height="186dp" >
+    </ListView>
+
+</LinearLayout>

--- a/Tinfoil-for-Facebook/src/main/res/values/strings.xml
+++ b/Tinfoil-for-Facebook/src/main/res/values/strings.xml
@@ -43,6 +43,7 @@
     <string name="menu_refresh">Refresh</string>
     <string name="menu_notifications">Notifications</string>
     <string name="menu_messages">Messages</string>
+    <string name="menu_tag">Tag friend</string>
     <string name="menu_preferences">Preferences</string>
     <string name="menu_about">About</string>
     <string name="menu_exit">Kill</string>
@@ -64,6 +65,9 @@
     <string name="prefs_proxy_host">Proxy host</string>
     <string name="prefs_proxy_port">Proxy port</string>
 
+	<string name="prefs_api">Use Facebook API features</string>
+	<string name="prefs_api_sry">If enabled, Tinfoil will request a Facebook API access token to provide features such as inline friend tagging.</string>
+    
     <array name="prefs_mobile_site_list">
         <item>Auto</item>
         <item>Force mobile site</item>
@@ -74,6 +78,11 @@
         <item>mobile</item>
         <item>desktop</item>
     </array>
+    
+    <!-- Tagging -->
+    <string name="tag_in_hint">Search friends</string>
+    <string name="tag_out_hint">Tag will appear here</string>
+    <string name="tag_done_button">Tag</string>
 
     <string name="pref_about">About</string>
     <string name="pref_about_sry">Written by Daniel Velazco. Click here for more information.</string>

--- a/Tinfoil-for-Facebook/src/main/res/xml/main_preferences.xml
+++ b/Tinfoil-for-Facebook/src/main/res/xml/main_preferences.xml
@@ -36,6 +36,12 @@
             android:key="prefs_mobile_site"
             android:summary="@string/prefs_mobile_site_sry"
             android:title="@string/prefs_mobile_site" />
+        
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="prefs_api"
+            android:summary="@string/prefs_api_sry"
+            android:title="@string/prefs_api" />
 
     </PreferenceCategory>
     <PreferenceCategory


### PR DESCRIPTION
Okay, this is the PR that requires discussion.

I was annoyed that m.facebook.com doesn't support tagging friends in status updates and comments the same way you can on the desktop site (i.e. just by typing their name). I discovered that [it _is_ possible to do it on mobile](https://webapps.stackexchange.com/questions/27576/how-to-tag-friends-via-mobile-web-site-m-facebook-com). So I wanted to add this functionality to Tinfoil.

The problem is that it requires cooperation with a Facebook app, so that it can have access to your friends list. The app I created is [this one](https://developers.facebook.com/apps/266257470187937) and it has literally no code in it -- it exists to create an API key, and then it redirects to a URL that doesn't exist, and Tinfoil intercepts that.

So, see what you think of the tagging function here! You have to go to the preferences to turn it on, and then while you're typing a status update or comment you click on the "Tag Friend" menu item. When you select one to tag, it inserts a cryptic code into the current text field, and that turns into a tag once you submit it.
