### PR TITLE
Enable messenger in default and force-mobile configs.

### DIFF
--- a/app/src/main/java/com/danvelazco/fbwrapper/activity/BaseFacebookWebViewActivity.java
+++ b/app/src/main/java/com/danvelazco/fbwrapper/activity/BaseFacebookWebViewActivity.java
@@ -327,14 +327,16 @@ public abstract class BaseFacebookWebViewActivity extends Activity implements
             if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.JELLY_BEAN_MR2) {
                 mWebSettings.setUserAgentString(USER_AGENT_MOBILE_OLD);
             } else {
-                mWebSettings.setUserAgentString(USER_AGENT_MOBILE);
+                //mWebSettings.setUserAgentString(USER_AGENT_MOBILE);
+                mWebSettings.setUserAgentString(USER_AGENT_DESKTOP);
             }
         } else if (force && !mobile && !facebookBasic) {
             mWebSettings.setUserAgentString(USER_AGENT_DESKTOP);
         } else if (force && mobile && facebookBasic) {
             mWebSettings.setUserAgentString(USER_AGENT_BASIC);
         } else {
-            mWebSettings.setUserAgentString(null);
+            //mWebSettings.setUserAgentString(null);
+            mWebSettings.setUserAgentString(USER_AGENT_DESKTOP);
         }
     }
 


### PR DESCRIPTION
Unless forcing a specific site other than mobile, use the
desktop user-agent string. This will convince Facebook
to let you see your messages.

I did not set the desktop user agent for old clients, because
I was not able to test that setup.